### PR TITLE
Fetch tags before installation

### DIFF
--- a/db/yara
+++ b/db/yara
@@ -4,6 +4,7 @@ R2PM_GIT "https://github.com/VirusTotal/yara"
 R2PM_DESC "[syspkg] yara library and commandline tools from git"
 
 R2PM_INSTALL() {
+	git fetch --tags
 	git checkout v4.0.0
 #	export CFLAGS="-fPIC -I/usr/local/include"
 	${SHELL} bootstrap.sh


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Yara repository tags must be fetched before checking out.
