### PR TITLE
Bump yara version to 4.0.1

### DIFF
--- a/db/yara
+++ b/db/yara
@@ -5,7 +5,7 @@ R2PM_DESC "[syspkg] yara library and commandline tools from git"
 
 R2PM_INSTALL() {
 	git fetch --tags
-	git checkout v4.0.0
+	git checkout v4.0.1
 #	export CFLAGS="-fPIC -I/usr/local/include"
 	${SHELL} bootstrap.sh
 	export CFLAGS="-fPIC"


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**
New version of Yara is available: https://github.com/VirusTotal/yara/releases/tag/v4.0.1
