### PR TITLE
Adding support for BA2 CPU

### DIFF
--- a/db/ba2
+++ b/db/ba2
@@ -1,0 +1,18 @@
+R2PM_BEGIN
+
+R2PM_GIT "https://github.com/radareorg/radare2-extras"
+R2PM_DESC "[r2-arch] Beyond Architecture 2 disassembler plugin"
+
+R2PM_INSTALL() {
+	./configure --prefix="${R2PM_PREFIX}" || exit 1
+	cd libr/asm/p || exit 1
+	${MAKE} clean
+	${MAKE} || exit 1
+	cp -f asm_ba2.${LIBEXT} "${R2PM_PLUGDIR}" || exit 1
+}
+
+R2PM_UNINSTALL() {
+	rm -f "${R2PM_PLUGDIR}/asm_ba2."*
+}
+
+R2PM_END


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Adding support for NXP Beyond Architecture 2 CPU disassembly and analysis. (Used for example in JN5169 ZigBee CPU).

...

**Test plan**

I opened a few .elf files for this CPU.

