### PR TITLE
Fix blackfin compilation

### DIFF
--- a/db/blackfin
+++ b/db/blackfin
@@ -7,7 +7,7 @@ R2PM_INSTALL() {
 	./configure --prefix="${R2PM_PREFIX}" || exit 1
 	cd libr/asm/p || exit 1
 	${MAKE} clean
-	${MAKE} blackfin || exit 1
+	${MAKE} asm_blackfin.${LIBEXT} || exit 1
 	cp -f asm_blackfin.${LIBEXT} "${R2PM_PLUGDIR}" || exit 1
 }
 


### PR DESCRIPTION
When compiling blackfin with `r2pm -i blackfin` you would get:
```
gmake: *** No rule to make target 'blackfin'.  Stop.
```