### PR TITLE
Set git dir == package name for r2dec, r2ghidra-dec and retdec-r2plugin

### DIFF
--- a/db/r2dec
+++ b/db/r2dec
@@ -1,11 +1,11 @@
 R2PM_BEGIN
 
-R2PM_GIT "https://github.com/radareorg/r2dec-js"
+R2PM_GIT "https://github.com/radareorg/r2dec-js" r2dec
 R2PM_DESC "[r2-plugin] Experimental Decompiler written in javascript on top of r2"
 BINDIR="${R2PM_BINDIR}"
 
 R2PM_INSTALL() {
-	${MAKE} -C p || exit 1
+	CFLAGS="-DR2DEC_HOME=\\\"${R2PM_GITDIR}/r2dec\\\"" ${MAKE} -C p || exit 1
 }
 
 R2PM_UNINSTALL() {

--- a/db/r2ghidra-dec
+++ b/db/r2ghidra-dec
@@ -1,6 +1,6 @@
 R2PM_BEGIN
 
-R2PM_GIT "https://github.com/radareorg/r2ghidra-dec.git"
+R2PM_GIT "https://github.com/radareorg/r2ghidra-dec"
 R2PM_DESC "[r2-core] Ghidra Decompiler Plugin"
 
 R2PM_DOC=""

--- a/db/retdec-r2plugin
+++ b/db/retdec-r2plugin
@@ -1,6 +1,6 @@
 R2PM_BEGIN
 
-R2PM_GIT "https://github.com/avast/retdec-r2plugin.git"
+R2PM_GIT "https://github.com/avast/retdec-r2plugin"
 R2PM_DESC "[r2-core] RetDec plugin"
 
 R2PM_DOC=""


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Based on https://github.com/radareorg/radare2/pull/17357#issuecomment-666164765 and https://github.com/radareorg/radare2/pull/17442#issuecomment-673539719, this pr sets the git dir for r2dec, r2ghidra-dec and retdec-r2plugin to be the same as the package name. This is so `r2pm ci` for those packages actually does clean.

Also, compiling retdec-r2plugin takes ages.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

`r2pm -ci r2dec` / `r2ghidra-dec` / `retdec-r2plugin` actually cleans the package's git dir.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
