### PR TITLE
rlang-duktape: Add missing configure step && ignore clean failure

### DIFF
--- a/db/rlang-duktape
+++ b/db/rlang-duktape
@@ -4,7 +4,8 @@ R2PM_GIT "https://github.com/radareorg/radare2-rlang"
 R2PM_DESC "[rlang] Duktape JS RLang plugin #!duktape"
 
 R2PM_INSTALL() {
-	${MAKE} clean || exit 1
+	${MAKE} clean || sleep 0
+	./configure || exit 1
 	${MAKE} -C duktape || exit 1
 	${MAKE} -C duktape install R2PM_PLUGDIR="${R2PM_PLUGDIR}" || exit 1
 }


### PR DESCRIPTION
**Detailed description**

GitHub CI on radare2-extras broke because `make clean` target tries to include config.mk which does not exist until
`./configure` is executed in radare2-rlang for rlang-duktape package.

**Test plan**
Merge this commit, and then I can retest CI on r2e.