### PR TITLE
Bump yara version to 4.0.4

### DIFF
--- a/db/yara
+++ b/db/yara
@@ -5,7 +5,7 @@ R2PM_DESC "[syspkg] yara library and commandline tools from git"
 
 R2PM_INSTALL() {
 	git fetch --tags
-	git checkout v4.0.2
+	git checkout v4.0.4
 #	export CFLAGS="-fPIC -I/usr/local/include"
 	${SHELL} bootstrap.sh
 	export CFLAGS="-fPIC"


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

New bugfix version of yara: https://github.com/VirusTotal/yara/releases/tag/v4.0.4


**Test plan**

My personal tests and **test/extras/cmd/yara** tests are passing with the new version.
