### PR TITLE
Bump to yara v4.1.1

### DIFF
--- a/db/yara
+++ b/db/yara
@@ -5,7 +5,7 @@ R2PM_DESC "[syspkg] yara library and commandline tools from git"
 
 R2PM_INSTALL() {
 	git fetch --tags
-	git checkout v4.1.0
+	git checkout v4.1.1
 #	export CFLAGS="-fPIC -I/usr/local/include"
 	chmod +x bootstrap.sh
 	./bootstrap.sh


### PR DESCRIPTION
**Detailed description**
New version of Yara is available: https://github.com/VirusTotal/yara/releases/tag/v4.1.1

**Test plan**
Tests are passing.

**Closing issues**
None
