### PR TITLE
use $(CC) instead of gcc in imcat for portability

### DIFF
--- a/db/imcat
+++ b/db/imcat
@@ -4,7 +4,8 @@ R2PM_GIT "https://github.com/stolk/imcat"
 R2PM_DESC "image cat (png)"
 
 R2PM_INSTALL() {
-	$(CC) -o imcat imcat.c
+	[ -z "$CC" ] && CC=gcc
+	${CC} -o imcat imcat.c
 	${SUDO} mkdir -p "${R2PM_PREFIX}/bin"
 	${SUDO} cp -f imcat "${R2PM_PREFIX}/bin/imcat"
 }

--- a/db/imcat
+++ b/db/imcat
@@ -4,7 +4,7 @@ R2PM_GIT "https://github.com/stolk/imcat"
 R2PM_DESC "image cat (png)"
 
 R2PM_INSTALL() {
-	gcc -o imcat imcat.c
+	$(CC) -o imcat imcat.c
 	${SUDO} mkdir -p "${R2PM_PREFIX}/bin"
 	${SUDO} cp -f imcat "${R2PM_PREFIX}/bin/imcat"
 }


### PR DESCRIPTION
**Checklist**

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Not everybody uses gcc.
<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
