### PR TITLE
fix nproc

### DIFF
--- a/db/r2retdec
+++ b/db/r2retdec
@@ -5,15 +5,6 @@ R2PM_DESC "retdec decompiler plugin for radare2 (adds pdz command)"
 
 R2PM_DOC=""
 
-fetch_nproc() {
-	which nproc 2>/dev/null >/dev/null
-	if [ $? -eq 0 ]; then
-		nproc
-	else
-		echo 1
-	fi
-}
-
 R2PM_INSTALL() {
 	mkdir -p build && cd build || exit 1
 	if [ "`uname`" = Darwin ]; then
@@ -28,7 +19,7 @@ R2PM_INSTALL() {
 		-DBUILD_BUNDLED_RETDEC=ON \
 		-DRETDEC_INSTALL_PREFIX="${PWD}/install" || exit 1
 	fi
-	${MAKE} -j$(fetch_nproc) install || exit 1
+	${MAKE} -j$(nproc --all) install || exit 1
 }
 
 R2PM_UNINSTALL() {

--- a/db/r2retdec
+++ b/db/r2retdec
@@ -19,7 +19,8 @@ R2PM_INSTALL() {
 		-DBUILD_BUNDLED_RETDEC=ON \
 		-DRETDEC_INSTALL_PREFIX="${PWD}/install" || exit 1
 	fi
-	${MAKE} -j$(nproc --all) install || exit 1
+	${MAKE} -j2 || exit 1
+	${MAKE} install || exit 1
 }
 
 R2PM_UNINSTALL() {


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
Fix the issue while compiling r2pm with:

```bash
$ r2pm -ci r2retdec

INFO: Cleaning r2retdec

INFO: Using r2-5.8.7 and r2pm-5.8.7

INFO: Cleaning r2retdec

INFO: git clone --depth=10 --recursive https://github.com/radareorg/r2retdec /home/vboxuser/.local/share/radare2/r2pm/git//r2retdec

Cloning into '/home/vboxuser/.local/share/radare2/r2pm/git//r2retdec'...

remote: Enumerating objects: 138, done.

remote: Counting objects: 100% (138/138), done.

remote: Compressing objects: 100% (93/93), done.

remote: Total 138 (delta 47), reused 86 (delta 28), pack-reused 0

Receiving objects: 100% (138/138), 72.10 KiB | 1.90 MiB/s, done.

Resolving deltas: 100% (47/47), done.

INFO: Starting install for r2retdec

INFO: SCRIPT=<<EOF

INFO: 	mkdir -p build && cd build || exit 1

	if [ "`uname`" = Darwin ]; then

		cmake .. \

		-DRADARE2_INSTALL_PLUGDIR="${R2PM_PLUGDIR}" \

		-DBUILD_BUNDLED_RETDEC=ON \

		-DRETDEC_INSTALL_PREFIX="${PWD}/install" || exit 1

		-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/ \

	else

		cmake .. \

		-DRADARE2_INSTALL_PLUGDIR="${R2PM_PLUGDIR}" \

		-DBUILD_BUNDLED_RETDEC=ON \

		-DRETDEC_INSTALL_PREFIX="${PWD}/install" || exit 1

	fi

	${MAKE} -j$(fetch_nproc) install || exit 1

INFO: EOF

sh: 19: fetch_nproc: not found

make: *** No rule to make target 'install'.  Stop.
```